### PR TITLE
Updated the email.php document and registration page

### DIFF
--- a/email.php
+++ b/email.php
@@ -1,6 +1,6 @@
 <?php
 // Swift Mailer Library
-require_once 'F:\xampp\htdocs\knightridertest4\switftmailer\lib\swift_required.php';
+require_once 'F:\xampp\htdocs\knightridertest7\swiftmailer\lib\swift_required.php';
 
 // Mail Transport
 $transport = Swift_SmtpTransport::newInstance('ssl://smtp.gmail.com', 465)
@@ -11,18 +11,57 @@ $transport = Swift_SmtpTransport::newInstance('ssl://smtp.gmail.com', 465)
 $mailer = Swift_Mailer::newInstance($transport);
 
 // Create a message
-$message = Swift_Message::newInstance('Knight Riders Registration -- DO NOT REPLY')
-    ->setFrom(array($email => $fname)) // can be $_POST['email'] etc...
-    ->setTo(array($email => $lname)) // your email / multiple supported.
-    ->setBody('Thank you for signing up with Knight Riders! \r\n
-					Please click on or copy/paste the URL below to login. \r\n
-					(http://webdav.mga.edu/addison.gernannt/)', 'text/html');
+$message = Swift_Message::newInstance('[MGA KnightRiders] Please verify your email address. | DO NOT REPLY')
+    ->setFrom(array($email => '')) // can be $_POST['email'] etc...
+    ->setTo(array($email => '')) // your email / multiple supported.
+    ->setBody('
+	<div class="align" style="display: block;
+				position: relative;
+				max-width: 75%;
+				margin-left: auto;
+				margin-right: auto;"
+	>
+	<img class="logoBig" src="webdav.mga.edu/addison.gernannt/images/KRLogoHorizontal.jpg" alt="big logo"
+	style="display: block;
+				position: relative;
+				max-width:70%;
+				margin-left: auto;
+				margin-right: auto;"
+	>
+		<div class="spacer" style="height:26px">
+		<br style="line-height:26px">
+        </div>
+	<div class="paragraph" style="direction: ltr;
+				margin: 5px 15px;
+				padding-bottom: 20px;
+				position: relative;"
+	>
+			Thank you for signing up with KnightRider! 
+		<div class="spacer" style="height:26px">
+		<br style="line-height:26px">
+        </div>
+			By clicking the link below, you are verifying your email address and helping keep us secure. 
+		<br>
+		<br>
+			<a href="http://webdav.mga.edu/addison.gernannt">Verify email address
+			</a>
+
+	<hr>
+		<br>
+			You’re receiving this email because you recently created a new MGA KnightRider account.
+			If this wasn’t you, please ignore this email.
+		
+		
+        
+	</div>			
+			
+			', 'text/html'); //The email being sent out now is simply a link back to the login page.
 
 // Send the message
 if ($mailer->send($message)) {
-    echo 'Registration pending -- please check your email for verification';
+    echo 'Registration pending -- please check your email for verification.';
 } else {
-    echo 'Something is not quite right. Please check your information and resubmit.';
+    echo 'Something is not quite right. Please verify your information.';
 }
 
 ?>

--- a/mysqli_connect.php
+++ b/mysqli_connect.php
@@ -1,11 +1,11 @@
 <?php
 $servername = "168.16.222.102";
 $username = "addisongernannt";
-$password = "ILiveInMacon2!";
+$serverpassword = "ILiveInMacon2!";
 $dbname = "addisongernannt1617db";
 
 // Create connection
-$conn = new mysqli($servername, $username, $password, $dbname);
+$conn = new mysqli($servername, $username, $serverpassword, $dbname);
 
 // Check connection
 if ($conn->connect_error) {

--- a/registration.php
+++ b/registration.php
@@ -25,8 +25,8 @@
 		$errors = array(); //Set array to store error messages
 		
 		//Perform validation checks
-		if (strpbrk($email, '@') == FALSE)
-			{$errors[] = "Email must contain '@'.";}
+		if (strstr($email, '@mga.edu') == FALSE)
+			{$errors[] = "You must register with an MGA email address.";}
 		elseif (preg_match($regex_email,$email))
 			{$errors[] = "Email format is incorrect.";} //regular expression validation for email 
 		if (empty($_POST['registrationFnameInput']))


### PR DESCRIPTION
The email.php had it's $password changed to $serverpassword to avoid conflict with the registration page; hence, everyone's password suddenly because the server password.
This page now also includes the updated email message with html and grammar changes.

The registration page is updated to only accept mga.edu domain addresses.

The swiftmailer folder is now (correctly) renamed to "swiftmailer". -was "switftmailer", yay typos